### PR TITLE
fix: DELPHI-432

### DIFF
--- a/src/main/java/de/caritas/cob/userservice/api/tenant/TenantContextProvider.java
+++ b/src/main/java/de/caritas/cob/userservice/api/tenant/TenantContextProvider.java
@@ -1,6 +1,6 @@
 package de.caritas.cob.userservice.api.tenant;
 
-import static de.caritas.cob.userservice.api.tenant.TenantResolverService.TECHNICAL_TENANT_ID;
+import static de.caritas.cob.userservice.api.tenant.TenantContext.TECHNICAL_TENANT_ID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;

--- a/src/main/java/de/caritas/cob/userservice/api/tenant/TenantResolverService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/tenant/TenantResolverService.java
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class TenantResolverService {
 
-  public static final Long TECHNICAL_TENANT_ID = 0L;
   @NonNull CustomHeaderTenantResolver customHeaderTenantResolver;
 
   @NonNull SubdomainTenantResolver subdomainTenantResolver;

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/enquirynotification/scheduler/EnquiryNotificationScheduler.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/enquirynotification/scheduler/EnquiryNotificationScheduler.java
@@ -2,6 +2,7 @@ package de.caritas.cob.userservice.api.workflow.enquirynotification.scheduler;
 
 import static org.apache.commons.lang3.BooleanUtils.isTrue;
 
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
 import de.caritas.cob.userservice.api.workflow.enquirynotification.service.EnquiryNotificationService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -19,10 +20,13 @@ public class EnquiryNotificationScheduler {
   @Value("${enquiry.open.notification.enabled}")
   private Boolean enquiryNotificationsEnabled;
 
+  private final @NonNull TenantContextProvider tenantContextProvider;
+
   /** Entry method to build and send email notifications. */
   @Scheduled(cron = "${enquiry.open.notification.cron}")
   public void sendEmailNotificationsForOpenEnquiries() {
     if (isTrue(enquiryNotificationsEnabled)) {
+      tenantContextProvider.setTechnicalContextIfMultiTenancyIsEnabled();
       enquiryNotificationService.sendEmailNotificationsForOpenEnquiries();
     }
   }

--- a/src/main/java/de/caritas/cob/userservice/api/workflow/enquirynotification/service/EnquiryNotificationService.java
+++ b/src/main/java/de/caritas/cob/userservice/api/workflow/enquirynotification/service/EnquiryNotificationService.java
@@ -3,7 +3,6 @@ package de.caritas.cob.userservice.api.workflow.enquirynotification.service;
 import static de.caritas.cob.userservice.api.helper.CustomLocalDateTime.nowInUtc;
 import static de.caritas.cob.userservice.api.helper.EmailNotificationUtils.deserializeNotificationSettingsOrDefaultIfNull;
 import static de.caritas.cob.userservice.api.service.emailsupplier.EmailSupplier.TEMPLATE_DAILY_ENQUIRY_NOTIFICATION;
-import static java.util.Arrays.asList;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
@@ -18,15 +17,13 @@ import de.caritas.cob.userservice.api.service.ConsultantAgencyService;
 import de.caritas.cob.userservice.api.service.agency.AgencyService;
 import de.caritas.cob.userservice.api.service.consultingtype.ReleaseToggle;
 import de.caritas.cob.userservice.api.service.consultingtype.ReleaseToggleService;
+import de.caritas.cob.userservice.api.service.emailsupplier.TenantTemplateSupplier;
 import de.caritas.cob.userservice.api.service.helper.MailService;
 import de.caritas.cob.userservice.api.workflow.enquirynotification.model.EnquiriesNotificationMailContent;
 import de.caritas.cob.userservice.mailservice.generated.web.model.MailDTO;
 import de.caritas.cob.userservice.mailservice.generated.web.model.MailsDTO;
 import de.caritas.cob.userservice.mailservice.generated.web.model.TemplateDataDTO;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -49,6 +46,10 @@ public class EnquiryNotificationService {
   private final @NonNull AgencyService agencyService;
 
   private final @NonNull ReleaseToggleService releaseToggleService;
+  private final TenantTemplateSupplier tenantTemplateSupplier;
+
+  @Value("${multitenancy.enabled}")
+  private boolean multiTenancyEnabled;
 
   @Value("${enquiry.open.notification.check.hours}")
   private Long openEnquiryCheckHours;
@@ -96,17 +97,21 @@ public class EnquiryNotificationService {
 
   private Function<Entry<Long, Long>, EnquiriesNotificationMailContent> toMailContent(
       Map<Long, AgencyDTO> agencyIdToAgency) {
-    return agencyIdEnquiriesEntry -> {
-      var agencyId = agencyIdEnquiriesEntry.getKey();
-      var openEnquiries = agencyIdEnquiriesEntry.getValue();
-      AgencyDTO agency = agencyIdToAgency.get(agencyId);
-      var agencyName = agency == null ? UNKNOWN_AGENCY : agency.getName();
+    return entry -> {
+      var agencyId = entry.getKey();
+      var openEnquiries = entry.getValue();
+      var agency = agencyIdToAgency.get(agencyId);
+
       return EnquiriesNotificationMailContent.builder()
           .agencyId(agencyId)
           .amountOfOpenEnquiries(openEnquiries)
-          .agencyName(agencyName)
+          .agencyName(resolveAgencyName(agency))
           .build();
     };
+  }
+
+  private String resolveAgencyName(AgencyDTO agency) {
+    return Optional.ofNullable(agency).map(AgencyDTO::getName).orElse(UNKNOWN_AGENCY);
   }
 
   private void buildAndSendEnquiryNotificationMails(
@@ -133,21 +138,28 @@ public class EnquiryNotificationService {
 
   private MailDTO buildMailTO(
       Consultant consultant, EnquiriesNotificationMailContent enquiryNotificationContent) {
+    var templateAttributes = new ArrayList<TemplateDataDTO>();
+    templateAttributes.add(new TemplateDataDTO().key("subject").value(MAIL_SUBJECT));
+    templateAttributes.add(
+        new TemplateDataDTO().key("consultant_name").value(consultant.getFullName()));
+    templateAttributes.add(
+        new TemplateDataDTO().key("agency_name").value(enquiryNotificationContent.getAgencyName()));
+    templateAttributes.add(
+        new TemplateDataDTO()
+            .key("enquiries")
+            .value(String.valueOf(enquiryNotificationContent.getAmountOfOpenEnquiries())));
+
+    if (!multiTenancyEnabled) {
+      templateAttributes.add(new TemplateDataDTO().key("url").value(applicationBaseUrl));
+    } else {
+      templateAttributes.addAll(tenantTemplateSupplier.getTemplateAttributes());
+    }
+
     return new MailDTO()
         .template(TEMPLATE_DAILY_ENQUIRY_NOTIFICATION)
         .email(consultant.getEmail())
         .language(languageOf(consultant.getLanguageCode()))
-        .templateData(
-            asList(
-                new TemplateDataDTO().key("subject").value(MAIL_SUBJECT),
-                new TemplateDataDTO().key("consultant_name").value(consultant.getFullName()),
-                new TemplateDataDTO().key("url").value(applicationBaseUrl),
-                new TemplateDataDTO()
-                    .key("agency_name")
-                    .value(enquiryNotificationContent.getAgencyName()),
-                new TemplateDataDTO()
-                    .key("enquiries")
-                    .value(String.valueOf(enquiryNotificationContent.getAmountOfOpenEnquiries()))));
+        .templateData(templateAttributes);
   }
 
   private void buildAndSendNotificationEmail(List<MailDTO> mailsToSend) {

--- a/src/test/java/de/caritas/cob/userservice/api/tenant/TenantContextProviderTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/tenant/TenantContextProviderTest.java
@@ -1,6 +1,6 @@
 package de.caritas.cob.userservice.api.tenant;
 
-import static de.caritas.cob.userservice.api.tenant.TenantResolverService.TECHNICAL_TENANT_ID;
+import static de.caritas.cob.userservice.api.tenant.TenantContext.TECHNICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/enquirynotification/scheduler/EnquiryNotificationSchedulerTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/enquirynotification/scheduler/EnquiryNotificationSchedulerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
+import de.caritas.cob.userservice.api.tenant.TenantContextProvider;
 import de.caritas.cob.userservice.api.workflow.enquirynotification.service.EnquiryNotificationService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +22,8 @@ class EnquiryNotificationSchedulerTest {
 
   @Mock private EnquiryNotificationService enquiryNotificationService;
 
+  @Mock private TenantContextProvider tenantContextProvider;
+
   @Test
   void
       sendEmailNotificationsForOpenEnquiries_Should_callEnquiryNotificationService_When_featureIsEnabled() {
@@ -28,6 +31,7 @@ class EnquiryNotificationSchedulerTest {
 
     enquiryNotificationScheduler.sendEmailNotificationsForOpenEnquiries();
 
+    verify(tenantContextProvider).setTechnicalContextIfMultiTenancyIsEnabled();
     verify(enquiryNotificationService).sendEmailNotificationsForOpenEnquiries();
   }
 

--- a/src/test/java/de/caritas/cob/userservice/api/workflow/enquirynotification/service/EnquiryNotificationServiceTest.java
+++ b/src/test/java/de/caritas/cob/userservice/api/workflow/enquirynotification/service/EnquiryNotificationServiceTest.java
@@ -5,10 +5,7 @@ import static de.caritas.cob.userservice.api.service.emailsupplier.EmailSupplier
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import com.neovisionaries.i18n.LanguageCode;
@@ -218,10 +215,8 @@ class EnquiryNotificationServiceTest {
                     .key("subject")
                     .value("Online-Beratung | Unbeantwortete Erstanfragen"),
                 new TemplateDataDTO().key("consultant_name").value(consultantName),
-                new TemplateDataDTO().key("url").value("base/url"),
                 new TemplateDataDTO().key("agency_name").value(agencyName),
-                new TemplateDataDTO()
-                    .key("enquiries")
-                    .value(String.valueOf(amountOfOpenEnquiries))));
+                new TemplateDataDTO().key("enquiries").value(String.valueOf(amountOfOpenEnquiries)),
+                new TemplateDataDTO().key("url").value("base/url")));
   }
 }


### PR DESCRIPTION
* fix the email builder to send the missing tenant_name and tenant_claim fields.
* removed the duplicated TECHNICAL_TENANT_ID from TenantResolverService.java.
* updated all the needed tests.